### PR TITLE
Fix cannot create tables automatically

### DIFF
--- a/src/db.config.ts
+++ b/src/db.config.ts
@@ -10,6 +10,7 @@ const baseOptions: TypeOrmModuleOptions = {
   username: process.env.DB_USERNAME,
   database: process.env.DB_NAME,
   autoLoadEntities: true,
+  synchronize: true,
 };
 const port = 3306;
 


### PR DESCRIPTION
- TypeORM の `synchronize` オプションを有効化することで対応
- 本来は [Migration](https://typeorm.io/#/migrations) を利用するべき場面だと思われるが、時間がないのでこの対処法とする